### PR TITLE
fix final rounds calculator dates

### DIFF
--- a/app/euroleague/2025-26-final-rounds-calculator/page.tsx
+++ b/app/euroleague/2025-26-final-rounds-calculator/page.tsx
@@ -46,6 +46,20 @@ export default async function Home() {
   const scheduleXml = await scheduleResponse.text();
   const allScheduleGames = parseScheduleGames(scheduleXml);
 
+  // Compute date ranges per round from all games
+  const roundDates: Record<number, { minDate: string; maxDate: string }> = {};
+  for (const game of allScheduleGames) {
+    if (!game.date || game.gameday === undefined) continue;
+    const existing = roundDates[game.gameday];
+    const gameTime = new Date(game.date).getTime();
+    if (!existing) {
+      roundDates[game.gameday] = { minDate: game.date, maxDate: game.date };
+    } else {
+      if (gameTime < new Date(existing.minDate).getTime()) existing.minDate = game.date;
+      if (gameTime > new Date(existing.maxDate).getTime()) existing.maxDate = game.date;
+    }
+  }
+
   // Filter to unplayed games, drop rounds with no remaining games
   const remainingGames = allScheduleGames
     .filter((g) => !g.played)
@@ -71,6 +85,7 @@ export default async function Home() {
         <StandingsCalculator
           games={remainingGames}
           teams={teams}
+          roundDates={roundDates}
           playOffPosition={6}
           playInPosition={10}
         />

--- a/components/StandingsCalculator.jsx
+++ b/components/StandingsCalculator.jsx
@@ -59,6 +59,7 @@ const GameRow = ({ game, index, position, columns, selection, onSelectionChange 
 const StandingsCalculator = ({
   games,
   teams,
+  roundDates,
   playOffPosition,
   playInPosition,
 }) => {
@@ -249,6 +250,7 @@ const StandingsCalculator = ({
                     key={group.gameday}
                     gameday={group.gameday}
                     entries={group.entries}
+                    roundDateRange={roundDates?.[group.gameday]}
                     isOpen={openRounds.has(group.gameday)}
                     onToggle={() => toggleRound(group.gameday)}
                     renderGameRows={renderGameRows}
@@ -299,13 +301,13 @@ const StandingsCalculator = ({
 const RoundGroup = ({
   gameday,
   entries,
+  roundDateRange,
   isOpen,
   onToggle,
   renderGameRows,
 }) => {
-  // Get the date range from entries (already sorted by date)
-  const minDate = entries[0]?.game?.date;
-  const maxDate = entries[entries.length - 1]?.game?.date;
+  const minDate = roundDateRange?.minDate;
+  const maxDate = roundDateRange?.maxDate;
 
   return (
     <div className="border-b border-gray-800 last:border-b-0">

--- a/components/StandingsCalculator.jsx
+++ b/components/StandingsCalculator.jsx
@@ -316,7 +316,7 @@ const RoundGroup = ({
         onClick={onToggle}
       >
         <div className="flex items-center gap-2">
-          <span className="min-w-20">Round {gameday}</span>
+          <span className="w-20 shrink-0">Round {gameday}</span>
           {minDate && (
             <span className="text-gray-500 font-normal">
               {minDate === maxDate ? minDate : `${minDate} - ${maxDate}`}

--- a/components/StandingsCalculator.jsx
+++ b/components/StandingsCalculator.jsx
@@ -314,7 +314,7 @@ const RoundGroup = ({
         onClick={onToggle}
       >
         <div className="flex items-center gap-2">
-          <span>Round {gameday}</span>
+          <span className="min-w-20">Round {gameday}</span>
           {minDate && (
             <span className="text-gray-500 font-normal">
               {minDate === maxDate ? minDate : `${minDate} - ${maxDate}`}

--- a/components/StandingsCalculator.jsx
+++ b/components/StandingsCalculator.jsx
@@ -175,10 +175,14 @@ const StandingsCalculator = ({
     });
 
     const sortedGamedays = [...gamedayMap.keys()].sort((a, b) => a - b);
-    return sortedGamedays.map((gameday) => ({
-      gameday,
-      entries: gamedayMap.get(gameday),
-    }));
+    return sortedGamedays.map((gameday) => {
+      const entries = gamedayMap.get(gameday).sort((a, b) => {
+        const dateA = a.game.date ? new Date(a.game.date).getTime() : 0;
+        const dateB = b.game.date ? new Date(b.game.date).getTime() : 0;
+        return dateA - dateB;
+      });
+      return { gameday, entries };
+    });
   }, [games, hasGamedays]);
 
   // Expand the round closest to the current date
@@ -299,8 +303,9 @@ const RoundGroup = ({
   onToggle,
   renderGameRows,
 }) => {
-  // Get the date from the first game entry
-  const date = entries[0]?.game?.date;
+  // Get the date range from entries (already sorted by date)
+  const minDate = entries[0]?.game?.date;
+  const maxDate = entries[entries.length - 1]?.game?.date;
 
   return (
     <div className="border-b border-gray-800 last:border-b-0">
@@ -310,8 +315,10 @@ const RoundGroup = ({
       >
         <div className="flex items-center gap-2">
           <span>Round {gameday}</span>
-          {date && (
-            <span className="text-gray-500 font-normal">{date}</span>
+          {minDate && (
+            <span className="text-gray-500 font-normal">
+              {minDate === maxDate ? minDate : `${minDate} - ${maxDate}`}
+            </span>
           )}
         </div>
         {isOpen ? (


### PR DESCRIPTION
## Summary
- Display date range (min to max) per round instead of a single date
- Sort games within each round by date chronologically
- Use round starting date for determining which round to auto-expand
- Align round dates vertically with fixed-width round labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)