### PR TITLE
closes #31: show remaining schedule between tied teams

### DIFF
--- a/app/eurocup/page.tsx
+++ b/app/eurocup/page.tsx
@@ -3,7 +3,10 @@ import Navigation from "@/components/Navigation.jsx";
 import Standings from "@/components/Standings.jsx";
 import { Metadata, Viewport } from "next";
 import Image from "next/image.js";
-import { generateEurocupStandingsFormXml } from "../../standings.js";
+import {
+  generateEurocupStandingsFormXml,
+  parseScheduleGames,
+} from "../../standings.js";
 
 export const viewport: Viewport = {
   themeColor: "black",
@@ -28,17 +31,34 @@ export const metadata: Metadata = {
 
 export default async function Home() {
   // consts
-  const data = await fetch(
-    "https://api-live.euroleague.net/v1/results?seasoncode=U2025",
-    {
+  const [resultsResponse, scheduleResponse] = await Promise.all([
+    fetch("https://api-live.euroleague.net/v1/results?seasoncode=U2025", {
       next: { revalidate: 5 * 60 },
-    }
-  );
-  const xml = await data.text();
+    }),
+    fetch("https://api-live.euroleague.net/v1/schedules?seasonCode=U2025", {
+      next: { revalidate: 5 * 60 },
+    }),
+  ]);
+  const xml = await resultsResponse.text();
   const { standings: standingsA, teams: teamsA } =
     generateEurocupStandingsFormXml(xml, "A");
   const { standings: standingsB, teams: teamsB } =
     generateEurocupStandingsFormXml(xml, "B");
+
+  const scheduleXml = await scheduleResponse.text();
+  const allRemainingGames = parseScheduleGames(scheduleXml)
+    .filter((g) => !g.played)
+    .sort((a, b) => a.gameday - b.gameday || a.gameNumber - b.gameNumber);
+
+  // Split remaining games by group based on team codes in each group
+  const groupACodes = new Set(teamsA.map((t) => t.code));
+  const groupBCodes = new Set(teamsB.map((t) => t.code));
+  const remainingGamesA = allRemainingGames.filter(
+    (g) => groupACodes.has(g.homeCode) || groupACodes.has(g.awayCode)
+  );
+  const remainingGamesB = allRemainingGames.filter(
+    (g) => groupBCodes.has(g.homeCode) || groupBCodes.has(g.awayCode)
+  );
 
   const gamesA = standingsA
     .map((team) => team.wins + team.losses)
@@ -84,6 +104,7 @@ export default async function Home() {
                 teams={teamsA}
                 playOffPosition={2}
                 playInPosition={6}
+                remainingGames={remainingGamesA}
               />
             </div>
             <div className="pt-4">
@@ -93,6 +114,7 @@ export default async function Home() {
                 teams={teamsB}
                 playOffPosition={2}
                 playInPosition={6}
+                remainingGames={remainingGamesB}
               />
             </div>
           </>

--- a/app/eurocup/page.tsx
+++ b/app/eurocup/page.tsx
@@ -54,10 +54,10 @@ export default async function Home() {
   const groupACodes = new Set(teamsA.map((t) => t.code));
   const groupBCodes = new Set(teamsB.map((t) => t.code));
   const remainingGamesA = allRemainingGames.filter(
-    (g) => groupACodes.has(g.homeCode) || groupACodes.has(g.awayCode)
+    (g) => groupACodes.has(g.homeCode) && groupACodes.has(g.awayCode)
   );
   const remainingGamesB = allRemainingGames.filter(
-    (g) => groupBCodes.has(g.homeCode) || groupBCodes.has(g.awayCode)
+    (g) => groupBCodes.has(g.homeCode) && groupBCodes.has(g.awayCode)
   );
 
   const gamesA = standingsA

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,10 @@ import Standings from "@/components/Standings.jsx";
 import { Viewport } from "next";
 import Image from "next/image.js";
 import Link from "next/link";
-import { generateEuroleagueStandingsFormXml } from "../standings.js";
+import {
+  generateEuroleagueStandingsFormXml,
+  parseScheduleGames,
+} from "../standings.js";
 
 export const viewport: Viewport = {
   themeColor: "black",
@@ -14,17 +17,24 @@ export const viewport: Viewport = {
 
 export default async function Home() {
   // consts
-  const data = await fetch(
-    "https://api-live.euroleague.net/v1/results?seasoncode=E2025",
-    {
+  const [resultsResponse, scheduleResponse] = await Promise.all([
+    fetch("https://api-live.euroleague.net/v1/results?seasoncode=E2025", {
       next: { revalidate: 5 * 60 },
-    },
-  );
-  const xml = await data.text();
+    }),
+    fetch("https://api-live.euroleague.net/v1/schedules?seasonCode=E2025", {
+      next: { revalidate: 5 * 60 },
+    }),
+  ]);
+  const xml = await resultsResponse.text();
   const { standings, teams } = generateEuroleagueStandingsFormXml(xml);
   const games = standings
     .map((team) => team.wins + team.losses)
     .reduce((a, b) => Math.max(a, b), 0);
+
+  const scheduleXml = await scheduleResponse.text();
+  const remainingGames = parseScheduleGames(scheduleXml)
+    .filter((g) => !g.played)
+    .sort((a, b) => a.gameday - b.gameday || a.gameNumber - b.gameNumber);
 
   // state
   return (
@@ -74,6 +84,7 @@ export default async function Home() {
               teams={teams}
               playOffPosition={6}
               playInPosition={10}
+              remainingGames={remainingGames}
             />
           )}
         </main>

--- a/components/Standings.jsx
+++ b/components/Standings.jsx
@@ -104,12 +104,81 @@ const getPredictionDetails = (teamCodes, standings, teams) => {
   return finalStandings;
 };
 
+const getRemainingGamesBetweenTeams = (teamCodes, remainingGames) => {
+  if (!remainingGames || remainingGames.length === 0) return [];
+  const codeSet = new Set(teamCodes);
+  return remainingGames.filter(
+    (g) => codeSet.has(g.homeCode) && codeSet.has(g.awayCode)
+  );
+};
+
+const formatGameDate = (dateStr) => {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+  });
+};
+
+const RemainingGames = ({ games, teams }) => {
+  if (!games || games.length === 0) return null;
+
+  const teamsByCode = {};
+  teams.forEach((t) => {
+    teamsByCode[t.code] = t;
+  });
+
+  return (
+    <div>
+      <table className="table-auto w-full sm:w-auto">
+        <thead>
+          <tr>
+            <th
+              scope="col"
+              colSpan="4"
+              className="px-3 py-2 text-sm font-semibold text-white text-left"
+            >
+              Remaining schedule
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {games.map((game) => {
+            const home = teamsByCode[game.homeCode];
+            const away = teamsByCode[game.awayCode];
+            return (
+              <tr key={`${game.homeCode}-${game.awayCode}-${game.gameNumber}`}>
+                <td className="px-3 py-1 text-sm text-gray-400">
+                  {formatGameDate(game.date)}
+                </td>
+                <td className="px-3 py-1 text-sm text-gray-300">
+                  <span className="sm:hidden">{teamCodeToAbbreviation(game.homeCode)}</span>
+                  <span className="hidden sm:inline">{home?.name || game.homeCode}</span>
+                </td>
+                <td className="px-3 py-1 text-sm text-gray-500 text-center">
+                  vs
+                </td>
+                <td className="px-3 py-1 text-sm text-gray-300">
+                  <span className="sm:hidden">{teamCodeToAbbreviation(game.awayCode)}</span>
+                  <span className="hidden sm:inline">{away?.name || game.awayCode}</span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
 const Standings = ({
   standings,
   teams,
   playOffPosition,
   playInPosition,
   disableMiniStandings,
+  remainingGames,
 }) => {
   const [expandedTeam, setExpandedTeam] = useState();
 
@@ -198,16 +267,25 @@ const Standings = ({
             </Field>
           </div>
           {predictionModeEnabled && (
-            <div className="w-full mt-4 flex">
+            <div className="w-full mt-4">
               {predictionModeTeams?.length > 1 && (
-                <SmallTable
-                  title="Tie-break mini standings"
-                  details={getPredictionDetails(
-                    predictionModeTeams,
-                    standings,
-                    teams
-                  )}
-                />
+                <div className="flex flex-col lg:flex-row lg:gap-8">
+                  <SmallTable
+                    title="Tie-break mini standings"
+                    details={getPredictionDetails(
+                      predictionModeTeams,
+                      standings,
+                      teams
+                    )}
+                  />
+                  <RemainingGames
+                    games={getRemainingGamesBetweenTeams(
+                      predictionModeTeams,
+                      remainingGames
+                    )}
+                    teams={teams}
+                  />
+                </div>
               )}
               {predictionModeTeams.length <= 1 && (
                 <p className="text-sm">
@@ -394,10 +472,19 @@ const Standings = ({
                   <tr className="bg-white/5" key={`${team.code}-details`}>
                     <td className="hidden sm:table-cell"></td>
                     <td colSpan="9" className="px-2 py-4 text-sm w-max-content">
-                      <SmallTable
-                        title="Tie-break opponent"
-                        details={tieBreakerDetails}
-                      />
+                      <div className="flex flex-col lg:flex-row lg:gap-8">
+                        <SmallTable
+                          title="Tie-break opponent"
+                          details={tieBreakerDetails}
+                        />
+                        <RemainingGames
+                          games={getRemainingGamesBetweenTeams(
+                            [team.code, ...tieBreakerDetails.map((t) => t.code)],
+                            remainingGames
+                          )}
+                          teams={teams}
+                        />
+                      </div>
                       {!disableMiniStandings && (
                         <button
                           type="button"

--- a/components/Standings.jsx
+++ b/components/Standings.jsx
@@ -132,17 +132,9 @@ const RemainingGames = ({ games, teams }) => {
   return (
     <div>
       <table className="table-auto w-full sm:w-auto">
-        <thead>
-          <tr>
-            <th
-              scope="col"
-              colSpan="4"
-              className="px-3 py-2 text-sm font-semibold text-white text-left"
-            >
-              Remaining schedule
-            </th>
-          </tr>
-        </thead>
+        <caption className="px-3 py-2 text-sm font-semibold text-white text-left">
+          Remaining schedule
+        </caption>
         <tbody>
           {games.map((game) => {
             const home = teamsByCode[game.homeCode];

--- a/components/Standings.jsx
+++ b/components/Standings.jsx
@@ -159,7 +159,7 @@ const RemainingGames = ({ games, teams }) => {
                 <td className="px-3 py-1 text-sm text-gray-500 text-center">
                   vs
                 </td>
-                <td className="px-3 py-1 text-sm text-gray-300">
+                <td className="px-3 py-1 text-sm text-gray-300 text-right sm:text-left">
                   <span className="sm:hidden">{teamCodeToAbbreviation(game.awayCode)}</span>
                   <span className="hidden sm:inline">{away?.name || game.awayCode}</span>
                 </td>


### PR DESCRIPTION
## Summary
- Fetch schedule data on EuroLeague and EuroCup standings pages alongside results
- Display remaining games between teams involved in a tiebreak, showing date, home team vs away team
- Remaining schedule renders side-by-side with the mini standings table on larger screens, stacked on mobile
- Team names use abbreviations on small screens to prevent overflow

Closes #31

## Test plan
- [x] Verify tiebreak expanded row shows remaining games between tied teams
- [x] Verify mini standings mode shows remaining games between selected teams
- [x] Verify side-by-side layout on desktop and stacked layout on mobile
- [x] Verify team abbreviations on small screens
- [x] Verify EuroCup page correctly splits remaining games by group

🤖 Generated with [Claude Code](https://claude.com/claude-code)