### PR TITLE
Fix mini standings header overflow and spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .scrollbar-thin {
+    scrollbar-width: thin;
+    scrollbar-color: #374151 transparent;
+  }
+  .scrollbar-thin::-webkit-scrollbar {
+    height: 4px;
+  }
+  .scrollbar-thin::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .scrollbar-thin::-webkit-scrollbar-thumb {
+    background-color: #374151;
+    border-radius: 9999px;
+  }
+}
+
 :root {
   --background: #0a0a0a;
   --foreground: #ededed;

--- a/components/Standings.jsx
+++ b/components/Standings.jsx
@@ -226,7 +226,7 @@ const Standings = ({
       {!disableMiniStandings && (
         <div className="overflow-hidden rounded-lg border border-gray-700 px-4 py-5 sm:p-6 my-8">
           <div className="flex flex-col-reverse lg:flex-row w-full gap-4 lg:gap-8">
-            <div className="grow flex flex-row gap-2 justify-between overflow-auto py-2 lg:py-0">
+            <div className="grow flex flex-row gap-2 justify-between overflow-auto scrollbar-thin py-2 lg:py-0">
               {standings.map((team) => {
                 return (
                   <TeamBox

--- a/components/Standings.jsx
+++ b/components/Standings.jsx
@@ -226,7 +226,7 @@ const Standings = ({
       {!disableMiniStandings && (
         <div className="overflow-hidden rounded-lg border border-gray-700 px-4 py-5 sm:p-6 my-8">
           <div className="flex flex-col-reverse lg:flex-row w-full gap-4 lg:gap-8">
-            <div className="grow flex flex-row gap-2 justify-between overflow-auto scrollbar-thin py-2 lg:py-0">
+            <div className="grow flex flex-row gap-1 justify-between overflow-auto scrollbar-thin py-2 lg:py-0">
               {standings.map((team) => {
                 return (
                   <TeamBox


### PR DESCRIPTION
## Summary
- Style a thin dark scrollbar for the mini standings team row instead of Chrome's default ugly scrollbar
- Reduce gap between team boxes from `gap-2` to `gap-1` so they fit better on smaller screens

## Test plan
- [ ] Verify horizontal scroll works on the mini standings header when teams overflow
- [ ] Check scrollbar appearance on Chrome, Firefox, and Safari
- [ ] Confirm team boxes spacing looks correct on both mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)