### PR TITLE
add EuroLeague overtime game IDs for rounds 33-34

### DIFF
--- a/standings.js
+++ b/standings.js
@@ -33,7 +33,7 @@ import { DOMParser } from "xmldom";
 // -----------------------------
 // If you know a certain <game> was decided in overtime, list its <gamenumber>
 // (or whatever unique identifier you prefer). For example:
-const euroleagueOvertimeGameIDs = [86, 87, 168, 173, 221, 239, 253, 263, 273, 283];
+const euroleagueOvertimeGameIDs = [86, 87, 168, 173, 221, 239, 253, 263, 273, 283, 330, 333, 337, 340];
 const eurocupOvertimeGameIDs = [9];
 
 // -----------------------------


### PR DESCRIPTION
## Summary
- Add 4 new overtime game IDs (#330, #333, #337, #340) verified against [Wikipedia](https://en.wikipedia.org/wiki/2025%E2%80%9326_EuroLeague_regular_season)
- All 14 OT games now tracked: `[86, 87, 168, 173, 221, 239, 253, 263, 273, 283, 330, 333, 337, 340]`

| Game | Round | Match | Score |
|------|-------|-------|-------|
| #330 | R33 | Baskonia vs Crvena zvezda | 100-108 (OT) |
| #333 | R34 | Maccabi Tel Aviv vs Dubai | 104-100 (OT) |
| #337 | R34 | Barcelona vs Crvena zvezda | 92-88 (OT) |
| #340 | R34 | Partizan vs Valencia | 110-104 (2OT) |

## Test plan
- [x] Verify standings calculations exclude OT scores for the 4 new games
- [x] Compare standings output with official EuroLeague standings

🤖 Generated with [Claude Code](https://claude.com/claude-code)