### PR TITLE
fix 25/26 final rounds calculator regular-season filter

### DIFF
--- a/app/euroleague/2025-26-final-rounds-calculator/page.tsx
+++ b/app/euroleague/2025-26-final-rounds-calculator/page.tsx
@@ -46,7 +46,7 @@ export default async function Home() {
   const scheduleXml = await scheduleResponse.text();
   const REGULAR_SEASON_ROUNDS = 38;
   const allScheduleGames = parseScheduleGames(scheduleXml).filter(
-    (g) => g.gameday <= REGULAR_SEASON_ROUNDS
+    (g) => g.gameday >= 1 && g.gameday <= REGULAR_SEASON_ROUNDS
   );
 
   // Compute date ranges per round from all games

--- a/app/euroleague/2025-26-final-rounds-calculator/page.tsx
+++ b/app/euroleague/2025-26-final-rounds-calculator/page.tsx
@@ -44,7 +44,10 @@ export default async function Home() {
   const { teams } = generateEuroleagueStandingsFormXml(resultsXml);
 
   const scheduleXml = await scheduleResponse.text();
-  const allScheduleGames = parseScheduleGames(scheduleXml);
+  const REGULAR_SEASON_ROUNDS = 38;
+  const allScheduleGames = parseScheduleGames(scheduleXml).filter(
+    (g) => g.gameday <= REGULAR_SEASON_ROUNDS
+  );
 
   // Compute date ranges per round from all games
   const roundDates: Record<number, { minDate: string; maxDate: string }> = {};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,6 @@ import Navigation from "@/components/Navigation.jsx";
 import Standings from "@/components/Standings.jsx";
 import { Viewport } from "next";
 import Image from "next/image.js";
-import Link from "next/link";
 import {
   generateEuroleagueStandingsFormXml,
   parseScheduleGames,
@@ -38,58 +37,40 @@ export default async function Home() {
 
   // state
   return (
-    <>
-      <div className="flex items-center justify-center gap-x-6 bg-gray-900 px-6 py-2.5 sm:px-3.5">
-        <p className="text-sm/6 text-white">
-          <Link href="/euroleague/2025-26-final-rounds-calculator">
-            <strong className="font-semibold">Final Rounds Calculator</strong>
-            <svg
-              viewBox="0 0 2 2"
-              aria-hidden="true"
-              className="mx-2 inline size-0.5 fill-current"
-            >
-              <circle r={1} cx={1} cy={1} />
-            </svg>
-            Select the final rounds outcomes and check the final standings.
-            <span aria-hidden="true">&rarr;</span>
-          </Link>
-        </p>
-      </div>
-      <div className="overflow-auto min-h-screen p-4 pb-20 gap-16 sm:px-20 sm:p-8 font-[family-name:var(--font-geist-sans)]">
-        <main className="min-h-screen">
-          <Navigation />
-          <div className="w-full flex gap-2 items-center mb-4">
-            <div className="relative w-12 h-12">
-              <Image src="/images/euroleague.png" alt="Euroleague" fill />
-            </div>
-            <div>
-              <h1 className="text-base font-semibold text-white">
-                Real EuroLeague Standings 2025/26
-              </h1>
-              {games > 0 && (
-                <p className="max-w-4xl text-sm text-gray-300">
-                  Includes known tiebreakers and results after {games} games.
-                </p>
-              )}
-            </div>
+    <div className="overflow-auto min-h-screen p-4 pb-20 gap-16 sm:px-20 sm:p-8 font-[family-name:var(--font-geist-sans)]">
+      <main className="min-h-screen">
+        <Navigation />
+        <div className="w-full flex gap-2 items-center mb-4">
+          <div className="relative w-12 h-12">
+            <Image src="/images/euroleague.png" alt="Euroleague" fill />
           </div>
-          {games === 0 && (
-            <p className="text-gray-300 w-full text-center p-40">
-              No games played yet. Check back later for standings.
-            </p>
-          )}
-          {games > 0 && (
-            <Standings
-              standings={standings}
-              teams={teams}
-              playOffPosition={6}
-              playInPosition={10}
-              remainingGames={remainingGames}
-            />
-          )}
-        </main>
-        <Footer />
-      </div>
-    </>
+          <div>
+            <h1 className="text-base font-semibold text-white">
+              Real EuroLeague Standings 2025/26
+            </h1>
+            {games > 0 && (
+              <p className="max-w-4xl text-sm text-gray-300">
+                Includes known tiebreakers and results after {games} games.
+              </p>
+            )}
+          </div>
+        </div>
+        {games === 0 && (
+          <p className="text-gray-300 w-full text-center p-40">
+            No games played yet. Check back later for standings.
+          </p>
+        )}
+        {games > 0 && (
+          <Standings
+            standings={standings}
+            teams={teams}
+            playOffPosition={6}
+            playInPosition={10}
+            remainingGames={remainingGames}
+          />
+        )}
+      </main>
+      <Footer />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restrict the 2025/26 final rounds calculator to the 38 regular-season rounds so play-in and playoff games are no longer pulled in from the schedule endpoint.
- Drop the Final Rounds Calculator banner from the index page.

## Test plan
- [x] Open `/euroleague/2025-26-final-rounds-calculator` and confirm only regular-season rounds (1-38) appear.
- [x] Open `/` and confirm the banner at the top is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)